### PR TITLE
Refactor thread list handling

### DIFF
--- a/dabbad/capture.c
+++ b/dabbad/capture.c
@@ -275,19 +275,12 @@ void dabbad_capture_get(Dabba__DabbaService_Service * service,
 	Dabba__CaptureList capture_list = DABBA__CAPTURE_LIST__INIT;
 	Dabba__CaptureList *capturep = NULL;
 	struct packet_capture *pkt_capture;
-	struct nl_sock *sock;
-	struct nl_cache *cache = NULL;
 	size_t a = dabbad_capture_length_get();
 
 	assert(service);
 	assert(id_listp);
 
 	if (a == 0)
-		goto out;
-
-	cache = link_cache_alloc(&sock);
-
-	if (!cache)
 		goto out;
 
 	capture_list.list = calloc(a, sizeof(*capture_list.list));
@@ -365,5 +358,4 @@ void dabbad_capture_get(Dabba__DabbaService_Service * service,
 	}
 
 	free(capture_list.list);
-	link_cache_destroy(sock, cache);
 }

--- a/dabbad/capture.c
+++ b/dabbad/capture.c
@@ -95,10 +95,9 @@ static struct packet_capture_thread *dabbad_capture_find(const pthread_t id)
 {
 	struct packet_capture_thread *node;
 
-	for (node = dabbad_capture_first(); node;
-	     node = dabbad_capture_next(node))
-		if (node->thread.id == id)
-			break;
+	TAILQ_FOREACH(node, &capture_thread_head, entry)
+	    if (node->thread.id == id)
+		break;
 
 	return node;
 }

--- a/dabbad/capture.c
+++ b/dabbad/capture.c
@@ -40,10 +40,9 @@
 #include <assert.h>
 #include <limits.h>
 #include <sys/queue.h>
+#include <net/if.h>
 #include <arpa/inet.h>
 #include <linux/if_ether.h>
-#include <netlink/cache.h>
-#include <netlink/route/link.h>
 
 #include <libdabba/macros.h>
 #include <libdabba/interface.h>

--- a/dabbad/capture.c
+++ b/dabbad/capture.c
@@ -59,7 +59,7 @@
  */
 
 static TAILQ_HEAD(capture_thread_head,
-		  packet_capture_thread) capture_thread_head =
+		  packet_capture) capture_thread_head =
 TAILQ_HEAD_INITIALIZER(capture_thread_head);
 
 /**
@@ -68,7 +68,7 @@ TAILQ_HEAD_INITIALIZER(capture_thread_head);
  * \return Pointer to the first capture of the capture list
  */
 
-static struct packet_capture_thread *dabbad_capture_first(void)
+static struct packet_capture *dabbad_capture_first(void)
 {
 	return TAILQ_FIRST(&capture_thread_head);
 }
@@ -79,8 +79,8 @@ static struct packet_capture_thread *dabbad_capture_first(void)
  * \return Pointer to the next capture of the capture list
  */
 
-static struct packet_capture_thread *dabbad_capture_next(struct packet_capture_thread
-							 *capture_thread)
+static struct packet_capture *dabbad_capture_next(struct packet_capture
+						  *capture_thread)
 {
 	return capture_thread ? TAILQ_NEXT(capture_thread, entry) : NULL;
 }
@@ -91,9 +91,9 @@ static struct packet_capture_thread *dabbad_capture_next(struct packet_capture_t
  * \return Pointer to the capture matching the capture id
  */
 
-static struct packet_capture_thread *dabbad_capture_find(const pthread_t id)
+static struct packet_capture *dabbad_capture_find(const pthread_t id)
 {
-	struct packet_capture_thread *node;
+	struct packet_capture *node;
 
 	TAILQ_FOREACH(node, &capture_thread_head, entry)
 	    if (node->thread.id == id)
@@ -151,7 +151,7 @@ void dabbad_capture_stop(Dabba__DabbaService_Service * service,
 			 Dabba__ErrorCode_Closure closure, void *closure_data)
 {
 	Dabba__ErrorCode err = DABBA__ERROR_CODE__INIT;
-	struct packet_capture_thread *pkt_capture;
+	struct packet_capture *pkt_capture;
 	int rc;
 
 	assert(service);
@@ -191,7 +191,7 @@ void dabbad_capture_start(Dabba__DabbaService_Service * service,
 			  const Dabba__Capture * capturep,
 			  Dabba__ErrorCode_Closure closure, void *closure_data)
 {
-	struct packet_capture_thread *pkt_capture;
+	struct packet_capture *pkt_capture;
 	int sock, rc;
 
 	assert(service);
@@ -259,7 +259,7 @@ void dabbad_capture_get(Dabba__DabbaService_Service * service,
 {
 	Dabba__CaptureList capture_list = DABBA__CAPTURE_LIST__INIT;
 	Dabba__CaptureList *capturep = NULL;
-	struct packet_capture_thread *pkt_capture;
+	struct packet_capture *pkt_capture;
 	struct nl_sock *sock;
 	struct nl_cache *cache;
 	size_t a = 0;

--- a/dabbad/include/dabbad/capture.h
+++ b/dabbad/include/dabbad/capture.h
@@ -38,10 +38,10 @@
  * \brief Structure representing a capture thread
  */
 
-struct packet_capture_thread {
+struct packet_capture {
 	struct packet_rx rx; /**< packet capture structure */
 	struct packet_thread thread; /**< thread structure */
-	 TAILQ_ENTRY(packet_capture_thread) entry;/**< capture entry */
+	 TAILQ_ENTRY(packet_capture) entry;/**< capture entry */
 };
 
 struct packet_thread *dabbad_capture_thread_data_get(const pthread_t thread_id);

--- a/dabbad/include/dabbad/capture.h
+++ b/dabbad/include/dabbad/capture.h
@@ -41,6 +41,7 @@
 struct packet_capture_thread {
 	struct packet_rx rx; /**< packet capture structure */
 	struct packet_thread thread; /**< thread structure */
+	 TAILQ_ENTRY(packet_capture_thread) entry;/**< capture entry */
 };
 
 struct packet_thread *dabbad_capture_thread_data_get(const pthread_t thread_id);

--- a/dabbad/thread.c
+++ b/dabbad/thread.c
@@ -53,29 +53,6 @@ static struct packet_thread_queue {
 
 /**
  * \internal
- * \brief Returns the first thread of the thread list
- * \return Pointer to the first thread of the thread list
- */
-
-static struct packet_thread *dabbad_thread_first(void)
-{
-	return TAILQ_FIRST(&packet_thread_queue.head);
-}
-
-/**
- * \internal
- * \brief Returns next thread present in the thread list
- * \return Pointer to the next thread of the thread list
- */
-
-static struct packet_thread *dabbad_thread_next(struct packet_thread
-						*pkt_thread)
-{
-	return pkt_thread ? TAILQ_NEXT(pkt_thread, entry) : NULL;
-}
-
-/**
- * \internal
  * \brief Returns thread matching thread id present in the thread list
  * \return Pointer to the thread matching the thread id
  */
@@ -469,8 +446,7 @@ void dabbad_thread_get(Dabba__DabbaService_Service * service,
 
 	settingsp = *settings_list.list;
 
-	for (pkt_thread = dabbad_thread_first(); pkt_thread;
-	     pkt_thread = dabbad_thread_next(pkt_thread)) {
+	TAILQ_FOREACH(pkt_thread, &packet_thread_queue.head, entry) {
 		settingsp->has_sched_policy = settingsp->has_sched_priority = 1;
 		settingsp->has_type = 1;
 		settingsp->id->id = (uint64_t) pkt_thread->id;

--- a/dabbad/thread.c
+++ b/dabbad/thread.c
@@ -318,8 +318,10 @@ int dabbad_thread_start(struct packet_thread *pkt_thread,
 	if (!rc)
 		rc = pthread_detach(pkt_thread->id);
 
-	if (!rc)
+	if (!rc) {
 		TAILQ_INSERT_TAIL(&packet_thread_queue.head, pkt_thread, entry);
+		packet_thread_queue.length++;
+	}
 
 	return rc;
 }
@@ -348,6 +350,8 @@ int dabbad_thread_stop(struct packet_thread *pkt_thread)
 
 	if (!rc) {
 		TAILQ_REMOVE(&packet_thread_queue.head, node, entry);
+		assert(packet_thread_queue.length > 0);
+		packet_thread_queue.length--;
 	}
 
 	return rc;

--- a/dabbad/thread.c
+++ b/dabbad/thread.c
@@ -72,63 +72,6 @@ static struct packet_thread *dabbad_thread_next(struct packet_thread
 }
 
 /**
- * \brief Get the first thread from the thread list matching the input thread type
- * \param[in] type type of the next running thread to get
- * \return 	Pointer to the first thread element,
- * 		NULL when no thread are currently running
- */
-
-struct packet_thread *dabbad_thread_type_first(const enum packet_thread_type
-					       type)
-{
-	struct packet_thread *node;
-
-	for (node = dabbad_thread_first(); node;
-	     node = dabbad_thread_next(node))
-		if (node->type == type)
-			break;
-
-	return node;
-}
-
-/**
- * \brief Get the next thread from the thread list matching the input thread type
- * \param[in] pkt_thread current thread entry
- * \param[in] type type of the next running thread to get
- * \return 	Pointer to the next thread element,
- * 		\c NULL when \c pkt_thread was the last element
- */
-
-struct packet_thread *dabbad_thread_type_next(struct packet_thread *pkt_thread,
-					      const enum packet_thread_type
-					      type)
-{
-	for (pkt_thread = dabbad_thread_next(pkt_thread); pkt_thread;
-	     pkt_thread = dabbad_thread_next(pkt_thread))
-		if (pkt_thread->type == type)
-			break;
-
-	return pkt_thread;
-}
-
-/**
- * \brief Get the thread information from an existing pthread id
- * \param[in] thread_id pthread id to search
- * \return Pointer to the corresponding thread element, \c NULL when not found.
- */
-
-struct packet_thread *dabbad_thread_data_get(const pthread_t thread_id)
-{
-	struct packet_thread *node;
-
-	TAILQ_FOREACH(node, &packet_thread_head, entry)
-	    if (pthread_equal(thread_id, node->id))
-		break;
-
-	return node;
-}
-
-/**
  * \brief Set the thread scheduling policy and priority
  * \param[in] pkt_thread thread to modify
  * \param[in] sched_prio new scheduling priority to set
@@ -413,7 +356,7 @@ void dabbad_thread_modify(Dabba__DabbaService_Service * service,
 	assert(service);
 	assert(thread);
 
-	pkt_thread = dabbad_thread_data_get(thread->id->id);
+	pkt_thread = dabbad_thread_find(thread->id->id);
 
 	if (pkt_thread) {
 		dabbad_thread_sched_param_get(pkt_thread, &sched_prio,

--- a/dabbad/thread.c
+++ b/dabbad/thread.c
@@ -53,6 +53,17 @@ static struct packet_thread_queue {
 
 /**
  * \internal
+ * \brief Get the amount of thread in the thread list
+ * \return Thread list length
+ */
+
+static size_t dabbad_thread_length_get(void)
+{
+	return packet_thread_queue.length;
+}
+
+/**
+ * \internal
  * \brief Insert a new thread to the thread list tail
  */
 
@@ -424,7 +435,7 @@ void dabbad_thread_get(Dabba__DabbaService_Service * service,
 	Dabba__ThreadList *settings_listp = NULL;
 	Dabba__Thread *settingsp;
 	struct packet_thread *pkt_thread;
-	size_t a = packet_thread_queue.length, cs_len = 128;
+	size_t a = dabbad_thread_length_get(), cs_len = 128;
 	cpu_set_t run_on;
 	int rc = 0;
 

--- a/dabbad/thread.c
+++ b/dabbad/thread.c
@@ -427,17 +427,12 @@ void dabbad_thread_get(Dabba__DabbaService_Service * service,
 	Dabba__ThreadList *settings_listp = NULL;
 	Dabba__Thread *settingsp;
 	struct packet_thread *pkt_thread;
-	size_t a = 0, cs_len = 128;
+	size_t a = packet_thread_queue.length, cs_len = 128;
 	cpu_set_t run_on;
 	int rc = 0;
 
 	assert(service);
 	assert(id_listp);
-
-	for (pkt_thread = dabbad_thread_first(); pkt_thread;
-	     pkt_thread = dabbad_thread_next(pkt_thread)) {
-		a++;
-	}
 
 	if (a == 0)
 		goto out;

--- a/dabbad/thread.c
+++ b/dabbad/thread.c
@@ -53,6 +53,31 @@ static struct packet_thread_queue {
 
 /**
  * \internal
+ * \brief Insert a new thread to the thread list tail
+ */
+
+static void dabbad_thread_insert(struct packet_thread *const node)
+{
+	assert(node);
+	TAILQ_INSERT_TAIL(&packet_thread_queue.head, node, entry);
+	packet_thread_queue.length++;
+}
+
+/**
+ * \internal
+ * \brief Remove existing thread entry from the thread list
+ */
+
+static void dabbad_thread_remove(struct packet_thread *const node)
+{
+	assert(node);
+	assert(packet_thread_queue.length > 0);
+	TAILQ_REMOVE(&packet_thread_queue.head, node, entry);
+	packet_thread_queue.length--;
+}
+
+/**
+ * \internal
  * \brief Returns thread matching thread id present in the thread list
  * \return Pointer to the thread matching the thread id
  */
@@ -295,10 +320,8 @@ int dabbad_thread_start(struct packet_thread *pkt_thread,
 	if (!rc)
 		rc = pthread_detach(pkt_thread->id);
 
-	if (!rc) {
-		TAILQ_INSERT_TAIL(&packet_thread_queue.head, pkt_thread, entry);
-		packet_thread_queue.length++;
-	}
+	if (!rc)
+		dabbad_thread_insert(pkt_thread);
 
 	return rc;
 }
@@ -325,11 +348,8 @@ int dabbad_thread_stop(struct packet_thread *pkt_thread)
 
 	rc = pthread_cancel(node->id);
 
-	if (!rc) {
-		TAILQ_REMOVE(&packet_thread_queue.head, node, entry);
-		assert(packet_thread_queue.length > 0);
-		packet_thread_queue.length--;
-	}
+	if (!rc)
+		dabbad_thread_remove(node);
 
 	return rc;
 }

--- a/dabbad/thread.c
+++ b/dabbad/thread.c
@@ -72,6 +72,23 @@ static struct packet_thread *dabbad_thread_next(struct packet_thread
 }
 
 /**
+ * \internal
+ * \brief Returns thread matching thread id present in the thread list
+ * \return Pointer to the thread matching the thread id
+ */
+
+static struct packet_thread *dabbad_thread_find(const pthread_t id)
+{
+	struct packet_thread *node;
+
+	TAILQ_FOREACH(node, &packet_thread_head, entry)
+	    if (node->id == id)
+		break;
+
+	return node;
+}
+
+/**
  * \brief Set the thread scheduling policy and priority
  * \param[in] pkt_thread thread to modify
  * \param[in] sched_prio new scheduling priority to set


### PR DESCRIPTION
Currently there is only one thread list where all possible thread are stored.
But the code to retrieve them by type is complicated and not really readable.
There must be one thread list per thread type and also one thread global list.
It would also capture function to only access its private list and keep things contained
