### PR TITLE
Add command to stop all running captures

### DIFF
--- a/dabba/test/t1100-capture.sh
+++ b/dabba/test/t1100-capture.sh
@@ -145,18 +145,29 @@ do
         "
 done
 
-for i in `seq 0 9`
-do
-        test_expect_success PYTHON_YAML "Query capture thread id to stop" "
-            dictkeys2values captures $i id < parsed > result_id
-        "
+test_expect_success PYTHON_YAML "Query capture thread id to stop" "
+    dictkeys2values captures 0 id < parsed > result_id
+"
 
-        test_expect_success PYTHON_YAML "Stop capture thread #$(($i+1)) on loopback" "
-            '$DABBA_PATH'/dabba capture stop --id '$(cat result_id)' &&
-            '$DABBA_PATH'/dabba capture get > after &&
-            test_must_fail grep -wq -f result_id after
-        "
-done
+test_expect_success PYTHON_YAML "Stop capture thread #0 on loopback" "
+    '$DABBA_PATH'/dabba capture stop --id '$(cat result_id)' &&
+    '$DABBA_PATH'/dabba capture get > after &&
+    test_must_fail grep -wq -f result_id after
+"
+
+test_expect_success "Stop all running captures thread" "
+    '$DABBA_PATH'/dabba capture stop-all &&
+    '$DABBA_PATH'/dabba capture get > result
+"
+
+cat > expect << EOF
+---
+  captures:
+EOF
+
+test_expect_success "Check that the capture list is empty" "
+    test_cmp result expect
+"
 
 test_expect_success "Cleanup: Stop dabbad" "
     killall dabbad

--- a/dabba/test/t1200-thread.sh
+++ b/dabba/test/t1200-thread.sh
@@ -197,9 +197,12 @@ do
         "
 done
 
-test_expect_success PYTHON_YAML "Stop capture thread using thread output" "
-    '$DABBA_PATH'/dabba capture stop --id '$thread_id' &&
-    '$DABBA_PATH'/dabba thread get settings > after &&
+test_expect_success "Stop all running captures" "
+    '$DABBA_PATH'/dabba capture stop-all &&
+    '$DABBA_PATH'/dabba thread get settings > after
+"
+
+test_expect_success "Check if the capture thread is still present" "
     test_must_fail grep -wq '$thread_id' after
 "
 

--- a/dabbad/capture.c
+++ b/dabbad/capture.c
@@ -220,13 +220,13 @@ void dabbad_capture_stop_all(Dabba__DabbaService_Service * service,
 
 		rc = dabbad_thread_stop(&pkt_capture->thread);
 
-		if (!rc) {
-			dabbad_capture_remove(pkt_capture);
-			close(pkt_capture->rx.pcap_fd);
-			packet_mmap_destroy(&pkt_capture->rx.pkt_mmap);
-			free(pkt_capture);
+		if (rc)
 			break;
-		}
+
+		dabbad_capture_remove(pkt_capture);
+		close(pkt_capture->rx.pcap_fd);
+		packet_mmap_destroy(&pkt_capture->rx.pkt_mmap);
+		free(pkt_capture);
 	}
 
 	err.code = rc;

--- a/dabbad/include/dabbad/capture.h
+++ b/dabbad/include/dabbad/capture.h
@@ -58,4 +58,9 @@ void dabbad_capture_get(Dabba__DabbaService_Service * service,
 			const Dabba__ThreadIdList * id_listp,
 			Dabba__CaptureList_Closure closure, void *closure_data);
 
+void dabbad_capture_stop_all(Dabba__DabbaService_Service * service,
+			     const Dabba__Dummy * dummyp,
+			     Dabba__ErrorCode_Closure closure,
+			     void *closure_data);
+
 #endif				/* CAPTURE_H */

--- a/libdabba-rpc/dabba.proto
+++ b/libdabba-rpc/dabba.proto
@@ -287,4 +287,5 @@ service dabba_service
     rpc capture_get (thread_id_list) returns (capture_list);
     rpc capture_start (capture) returns (error_code);
     rpc capture_stop (thread_id) returns (error_code);
+    rpc capture_stop_all (dummy) returns (error_code);
 }


### PR DESCRIPTION
After creating a large amount of captures, it is very tricky to stop them all at once.
These changesets add a `capture stop-all` action to stop all running capture on a particular daemon.
