### PR TITLE
Refactor test path

### DIFF
--- a/dabba/test/dabba-test-lib.sh
+++ b/dabba/test/dabba-test-lib.sh
@@ -21,6 +21,7 @@
 
 DABBAD_PATH="$SHARNESS_TEST_DIRECTORY/../../dabbad"
 DABBA_PATH="$SHARNESS_TEST_DIRECTORY/../../dabba"
+PATH="$DABBA_PATH:$DABBAD_PATH:$PATH"
 
 PYTHON_PATH="$(command -v python)"
 ETHTOOL_PATH="$(command -v ethtool)"

--- a/dabba/test/t0000-basic.sh
+++ b/dabba/test/t0000-basic.sh
@@ -21,7 +21,7 @@ test_description='Test the basic'
 
 . ./sharness.sh
 
-test_expect_success 'check dabba executable presence' "'$SHARNESS_TEST_DIRECTORY'/../dabba > /dev/null"
+test_expect_success 'check dabba executable presence' "dabba > /dev/null"
 test_expect_success 'success is reported like this' ':'
 test_expect_failure 'pretend we have a known breakage' 'false'
 

--- a/dabba/test/t0001-help.sh
+++ b/dabba/test/t0001-help.sh
@@ -34,7 +34,7 @@ See 'dabba help <command> [<subcommand>]' for more specific information.
 EOF
 
 test_expect_success "Check dabba help output" "
-    '$DABBA_PATH'/dabba --help > result &&
+    dabba --help > result &&
     test_cmp expect result
 "
 

--- a/dabba/test/t1000-interface-status.sh
+++ b/dabba/test/t1000-interface-status.sh
@@ -43,24 +43,24 @@ test_expect_success "Setup: Stop already running dabbad" "
 "
 
 test_expect_success 'invoke dabba interface status w/o dabbad' "
-    test_expect_code 22 $DABBA_PATH/dabba interface status get
+    test_expect_code 22 dabba interface status get
 "
 
 test_expect_success "Setup: Start dabbad" "
-    '$DABBAD_PATH'/dabbad --daemonize
+    dabbad --daemonize
 "
 
 test_expect_success "Check 'dabba interface' help output" "
-    '$DABBA_PATH/dabba' help interface | cat <<EOF
+    dabba help interface | cat <<EOF
     q
     EOF &&
-    '$DABBA_PATH/dabba' interface --help | cat <<EOF
+    dabba interface --help | cat <<EOF
     q
     EOF
 "
 
 test_expect_success "invoke dabba interface status with dabbad" "
-    '$DABBA_PATH'/dabba interface status get > result &&
+    dabba interface status get > result &&
     grep '\- name: ' result > name_result &&
     generate_yaml_status > expected &&
     sort -o expected_sorted expected &&
@@ -95,11 +95,11 @@ cat > expected_promisc <<EOF
 $bool
 EOF
     test_expect_success TEST_DEV "Modify promiscuous mode on '$TEST_DEV'" "
-        '$DABBA_PATH'/dabba interface status modify --id '$TEST_DEV' --promiscuous '$bool'
+        dabba interface status modify --id '$TEST_DEV' --promiscuous '$bool'
     "
 
     test_expect_success TEST_DEV "Fetch status information of '$TEST_DEV'" "
-        '$DABBA_PATH'/dabba interface status get --id '$TEST_DEV' > result
+        dabba interface status get --id '$TEST_DEV' > result
     "
 
     test_expect_success TEST_DEV,PYTHON_YAML "Parse '$TEST_DEV' interface status YAML output" "

--- a/dabba/test/t1001-interface-driver.sh
+++ b/dabba/test/t1001-interface-driver.sh
@@ -26,15 +26,15 @@ test_expect_success "Setup: Stop already running dabbad" "
 "
 
 test_expect_success 'invoke dabba interface driver command w/o dabbad' "
-    test_expect_code 22 $DABBA_PATH/dabba interface driver get
+    test_expect_code 22 dabba interface driver get
 "
 
 test_expect_success "Setup: Start dabbad" "
-    '$DABBAD_PATH'/dabbad --daemonize
+    dabbad --daemonize
 "
 
 test_expect_success 'invoke dabba interface driver command with dabbad' "
-    '$DABBA_PATH'/dabba interface driver get > result
+    dabba interface driver get > result
 "
 
 test_expect_success PYTHON_YAML "Parse interface driver YAML output" "

--- a/dabba/test/t1002-interface-settings.sh
+++ b/dabba/test/t1002-interface-settings.sh
@@ -28,15 +28,15 @@ test_expect_success "Setup: Stop already running dabbad" "
 "
 
 test_expect_success 'invoke dabba interface settings command w/o dabbad' "
-    test_expect_code 22 $DABBA_PATH/dabba interface settings get
+    test_expect_code 22 dabba interface settings get
 "
 
 test_expect_success "Setup: Start dabbad" "
-    '$DABBAD_PATH'/dabbad --daemonize
+    dabbad --daemonize
 "
 
 test_expect_success 'invoke dabba interface settings command with dabbad' "
-    '$DABBA_PATH'/dabba interface settings get > result
+    dabba interface settings get > result
 "
 
 test_expect_success PYTHON_YAML "Parse interface settings YAML output" "
@@ -90,11 +90,11 @@ do
     "
 
     test_expect_success TEST_DEV "Modify test interface $item" "
-        '$DABBA_PATH'/dabba interface settings modify --id '$TEST_DEV' --$item '$test_value'
+        dabba interface settings modify --id '$TEST_DEV' --$item '$test_value'
     "
 
     test_expect_success TEST_DEV "Fetch test interface settings" "
-        '$DABBA_PATH'/dabba interface settings get --id '$TEST_DEV' > result
+        dabba interface settings get --id '$TEST_DEV' > result
     "
 
     test_expect_success TEST_DEV,PYTHON_YAML "Parse test interface settings YAML output" "

--- a/dabba/test/t1003-interface-capabilities.sh
+++ b/dabba/test/t1003-interface-capabilities.sh
@@ -111,15 +111,15 @@ test_expect_success "Setup: Stop already running dabbad" "
 "
 
 test_expect_success 'invoke dabba interface capabilities command w/o dabbad' "
-    test_expect_code 22 $DABBA_PATH/dabba interface capabilities get
+    test_expect_code 22 dabba interface capabilities get
 "
 
 test_expect_success "Setup: Start dabbad" "
-    '$DABBAD_PATH'/dabbad --daemonize
+    dabbad --daemonize
 "
 
 test_expect_success 'invoke dabba interface capabilities command with dabbad' "
-    '$DABBA_PATH'/dabba interface capabilities get > result
+    dabba interface capabilities get > result
 "
 
 test_expect_success PYTHON_YAML "Parse interface capabilities YAML output" "
@@ -167,7 +167,7 @@ do
 done
 
 test_expect_success TEST_DEV "Fetch '$TEST_DEV' capabilities" "
-    '$DABBA_PATH'/dabba interface capabilities get --id '$TEST_DEV' > result
+    dabba interface capabilities get --id '$TEST_DEV' > result
 "
 
 test_expect_success TEST_DEV,PYTHON_YAML "Parse '$TEST_DEV' capabilities YAML output" "
@@ -189,8 +189,8 @@ do
             for status in False True
             do
                 test_expect_success TEST_DEV,PYTHON_YAML "Modify '$TEST_DEV' ${speed}Mbps $duplex duplex to $status" "
-                    '$DABBA_PATH'/dabba interface capabilities modify --id '$TEST_DEV' --speed '$speed' --'$duplex'-duplex '$status' &&
-                    '$DABBA_PATH'/dabba interface capabilities get --id '$TEST_DEV' > mod_result
+                    dabba interface capabilities modify --id '$TEST_DEV' --speed '$speed' --'$duplex'-duplex '$status' &&
+                    dabba interface capabilities get --id '$TEST_DEV' > mod_result
                 "
 
                 test_expect_success TEST_DEV,PYTHON_YAML "Parse modified '$TEST_DEV' capabilities YAML output" "

--- a/dabba/test/t1004-interface-pause.sh
+++ b/dabba/test/t1004-interface-pause.sh
@@ -26,15 +26,15 @@ test_expect_success "Setup: Stop already running dabbad" "
 "
 
 test_expect_success 'invoke dabba interface pause command w/o dabbad' "
-    test_expect_code 22 $DABBA_PATH/dabba interface pause get 
+    test_expect_code 22 dabba interface pause get
 "
 
 test_expect_success "Setup: Start dabbad" "
-    '$DABBAD_PATH'/dabbad --daemonize
+    dabbad --daemonize
 "
 
 test_expect_success 'invoke dabba interface pause command with dabbad' "
-    '$DABBA_PATH'/dabba interface pause get > result
+    dabba interface pause get > result
 "
 
 test_expect_success PYTHON_YAML "Parse interface pause YAML output" "
@@ -74,7 +74,7 @@ do
 done
 
 test_expect_success TEST_DEV "Fetch '$TEST_DEV' pause settings" "
-    '$DABBA_PATH'/dabba interface pause get --id '$TEST_DEV' > result
+    dabba interface pause get --id '$TEST_DEV' > result
 "
 
 test_expect_success TEST_DEV,PYTHON_YAML "Parse '$TEST_DEV' coalesce YAML output" "
@@ -87,8 +87,8 @@ do
 
     if [ "$value" = "True" ]; then
         test_expect_success TEST_DEV,PYTHON_YAML "Modify '$TEST_DEV' $feature pause settings" "
-            '$DABBA_PATH'/dabba interface pause modify --id '$TEST_DEV' --'$feature' False &&
-            '$DABBA_PATH'/dabba interface pause get --id '$TEST_DEV' > mod_result
+            dabba interface pause modify --id '$TEST_DEV' --'$feature' False &&
+            dabba interface pause get --id '$TEST_DEV' > mod_result
         "
 
         test_expect_success TEST_DEV,PYTHON_YAML "Parse modified '$TEST_DEV' pause YAML output" "
@@ -105,7 +105,7 @@ for feature in autoneg rx tx
 do
     value=$(dictkeys2values interfaces 0 pause "$feature" < parsed)
     test_expect_success TEST_DEV,PYTHON_YAML "Modify '$TEST_DEV' $feature pause to previous value" "
-        '$DABBA_PATH'/dabba interface pause modify --id '$TEST_DEV' --'$feature' '$value'
+        dabba interface pause modify --id '$TEST_DEV' --'$feature' '$value'
     "
 done
 

--- a/dabba/test/t1005-interface-coalesce.sh
+++ b/dabba/test/t1005-interface-coalesce.sh
@@ -72,15 +72,15 @@ test_expect_success "Setup: Stop already running dabbad" "
 "
 
 test_expect_success 'invoke dabba interface coalesce command w/o dabbad' "
-    test_expect_code 22 $DABBA_PATH/dabba interface coalesce get
+    test_expect_code 22 dabba interface coalesce get
 "
 
 test_expect_success "Setup: Start dabbad" "
-    '$DABBAD_PATH'/dabbad --daemonize
+    dabbad --daemonize
 "
 
 test_expect_success 'invoke dabba interface coalesce command with dabbad' "
-    '$DABBA_PATH'/dabba interface coalesce get > result
+    dabba interface coalesce get > result
 "
 
 test_expect_success PYTHON_YAML "Parse interface coalesce YAML output" "
@@ -135,7 +135,7 @@ do
 done
 
 test_expect_success TEST_DEV "Fetch '$TEST_DEV' coalesce settings" "
-    '$DABBA_PATH'/dabba interface coalesce get --id '$TEST_DEV' > result
+    dabba interface coalesce get --id '$TEST_DEV' > result
 "
 
 test_expect_success TEST_DEV,PYTHON_YAML "Parse '$TEST_DEV' coalesce YAML output" "
@@ -149,8 +149,8 @@ do
 
     if [ "$value" != "0" ]; then
         test_expect_success TEST_DEV,PYTHON_YAML "Modify '$TEST_DEV' $feature value" "
-            '$DABBA_PATH'/dabba interface coalesce modify --id '$TEST_DEV' --'$ethtool_pattern' 50 &&
-            '$DABBA_PATH'/dabba interface coalesce get --id '$TEST_DEV' > mod_result
+            dabba interface coalesce modify --id '$TEST_DEV' --'$ethtool_pattern' 50 &&
+            dabba interface coalesce get --id '$TEST_DEV' > mod_result
         "
 
         test_expect_success TEST_DEV,PYTHON_YAML "Parse modified '$TEST_DEV' coalesce YAML output" "
@@ -162,7 +162,7 @@ do
         "
 
         test_expect_success TEST_DEV,PYTHON_YAML "Modify '$TEST_DEV' $feature to previous value" "
-            '$DABBA_PATH'/dabba interface coalesce modify --id '$TEST_DEV' --'$ethtool_pattern' '$value'
+            dabba interface coalesce modify --id '$TEST_DEV' --'$ethtool_pattern' '$value'
         "
     fi
 done
@@ -178,8 +178,8 @@ do
 
             if [ "$value" != "0" ]; then
                 test_expect_success TEST_DEV,PYTHON_YAML "Modify '$TEST_DEV' $direction $feature $type value" "
-                    '$DABBA_PATH'/dabba interface coalesce modify --id '$TEST_DEV' --'$ethtool_pattern' 50 &&
-                    '$DABBA_PATH'/dabba interface coalesce get --id '$TEST_DEV' > mod_result
+                    dabba interface coalesce modify --id '$TEST_DEV' --'$ethtool_pattern' 50 &&
+                    dabba interface coalesce get --id '$TEST_DEV' > mod_result
                 "
 
                 test_expect_success TEST_DEV,PYTHON_YAML "Parse modified '$TEST_DEV' coalesce YAML output" "
@@ -191,7 +191,7 @@ do
                 "
 
                 test_expect_success TEST_DEV,PYTHON_YAML "Modify '$TEST_DEV' $direction $feature $type to previous value" "
-                    '$DABBA_PATH'/dabba interface coalesce modify --id '$TEST_DEV' --'$ethtool_pattern' '$value'
+                    dabba interface coalesce modify --id '$TEST_DEV' --'$ethtool_pattern' '$value'
                 "
             fi
         done
@@ -202,8 +202,8 @@ do
 
     if [ "$value" = "True" ]; then
         test_expect_success TEST_DEV,PYTHON_YAML "Modify '$TEST_DEV' $direction adaptive value" "
-            '$DABBA_PATH'/dabba interface coalesce modify --id '$TEST_DEV' --'$ethtool_pattern' false &&
-            '$DABBA_PATH'/dabba interface coalesce get --id '$TEST_DEV' > mod_result
+            dabba interface coalesce modify --id '$TEST_DEV' --'$ethtool_pattern' false &&
+            dabba interface coalesce get --id '$TEST_DEV' > mod_result
         "
 
         test_expect_success TEST_DEV,PYTHON_YAML "Parse modified '$TEST_DEV' coalesce YAML output" "
@@ -215,7 +215,7 @@ do
         "
 
         test_expect_success TEST_DEV,PYTHON_YAML "Modify '$TEST_DEV' $direction adaptive to previous value" "
-            '$DABBA_PATH'/dabba interface coalesce modify --id '$TEST_DEV' --'$ethtool_pattern' '$value'
+            dabba interface coalesce modify --id '$TEST_DEV' --'$ethtool_pattern' '$value'
         "
     fi
 done

--- a/dabba/test/t1006-interface-offload.sh
+++ b/dabba/test/t1006-interface-offload.sh
@@ -40,15 +40,15 @@ test_expect_success "Setup: Stop already running dabbad" "
 "
 
 test_expect_success 'invoke dabba interface offload command w/o dabbad' "
-    test_expect_code 22 $DABBA_PATH/dabba interface offload get
+    test_expect_code 22 dabba interface offload get
 "
 
 test_expect_success "Setup: Start dabbad" "
-    '$DABBAD_PATH'/dabbad --daemonize
+    dabbad --daemonize
 "
 
 test_expect_success 'invoke dabba interface offload command with dabbad' "
-    '$DABBA_PATH'/dabba interface offload get > result
+    dabba interface offload get > result
 "
 
 test_expect_success PYTHON_YAML "Parse interface offload YAML output" "
@@ -84,7 +84,7 @@ do
 done
 
 test_expect_success TEST_DEV "invoke dabba interface '$TEST_DEV' offload command with dabbad" "
-    '$DABBA_PATH'/dabba interface offload get --id '$TEST_DEV' > result
+    dabba interface offload get --id '$TEST_DEV' > result
 "
 
 test_expect_success TEST_DEV,PYTHON_YAML "Parse interface offload YAML output" "
@@ -99,8 +99,8 @@ do
 
     if [ "$(cat "output_$feature" 2> /dev/null)" = "True" ]; then
         test_expect_success TEST_DEV,PYTHON_YAML "Modify '$TEST_DEV' $feature" "
-            '$DABBA_PATH'/dabba interface offload modify --id '$TEST_DEV' --'$feature' false &&
-            '$DABBA_PATH'/dabba interface offload get --id '$TEST_DEV' > mod_result
+            dabba interface offload modify --id '$TEST_DEV' --'$feature' false &&
+            dabba interface offload get --id '$TEST_DEV' > mod_result
         "
 
         test_expect_success TEST_DEV,PYTHON_YAML "Parse modified '$TEST_DEV' offload YAML output" "
@@ -112,7 +112,7 @@ do
         "
 
         test_expect_success TEST_DEV,PYTHON_YAML "Modify '$TEST_DEV' $feature to previous status" "
-            '$DABBA_PATH'/dabba interface offload modify --id '$TEST_DEV' --'$feature' true
+            dabba interface offload modify --id '$TEST_DEV' --'$feature' true
         "
     fi
 done

--- a/dabba/test/t1100-capture.sh
+++ b/dabba/test/t1100-capture.sh
@@ -110,7 +110,7 @@ do
 
         test_expect_success PYTHON_YAML "Query capture YAML output" "
             echo 'any' > expect_interface &&
-            echo 'test$i.pcap' > expect_pcap &&
+            echo '$SHARNESS_TRASH_DIRECTORY/test$i.pcap' > expect_pcap &&
             echo '$ring_size' > expect_packet_mmap_size &&
             echo '$frame_nr' > expect_frame_number &&
             dictkeys2values captures $i id < parsed > result_id &&

--- a/dabba/test/t1100-capture.sh
+++ b/dabba/test/t1100-capture.sh
@@ -110,7 +110,7 @@ do
 
         test_expect_success PYTHON_YAML "Query capture YAML output" "
             echo 'any' > expect_interface &&
-            echo '$(pwd)/test$i.pcap' > expect_pcap &&
+            echo 'test$i.pcap' > expect_pcap &&
             echo '$ring_size' > expect_packet_mmap_size &&
             echo '$frame_nr' > expect_frame_number &&
             dictkeys2values captures $i id < parsed > result_id &&
@@ -160,7 +160,7 @@ test_expect_success PYTHON_YAML "Stop capture thread #0 on loopback" "
 "
 
 test_expect_success "Measure pcap file size before appending" "
-    stat -c %s '$(pwd)/test0.pcap' > before_size
+    stat -c %s test0.pcap > before_size
 "
 
 test_expect_success "Start a capture with pcap append" "
@@ -172,7 +172,7 @@ test_expect_success "Generate some traffic to capture" "
 "
 
 test_expect_success "Measure pcap file size after appending" "
-    stat -c %s '$(pwd)/test0.pcap' > after_size
+    stat -c %s test0.pcap > after_size
 "
 
 test_expect_success "Check that appended pcap file size grows" "

--- a/dabba/test/t1100-capture.sh
+++ b/dabba/test/t1100-capture.sh
@@ -40,41 +40,41 @@ frame_nr="16"
 ring_size="$(($frame_nr * 2048))" # 2kB are allocated for one ethernet frame
 
 test_expect_success "Setup: Start dabbad" "
-    '$DABBAD_PATH'/dabbad --daemonize
+    dabbad --daemonize
 "
 
 test_expect_success "Check 'dabba capture' help output" "
-    '$DABBA_PATH/dabba' help capture | cat <<EOF
+    dabba help capture | cat <<EOF
     q
     EOF &&
-    '$DABBA_PATH/dabba' capture --help | cat <<EOF
+    dabba' capture --help | cat <<EOF
     q
     EOF
 "
 
 test_expect_failure "Start capture thread on an invalid interface (too long)" "
-    test_expect_code 22 '$DABBA_PATH'/dabba capture start --interface lorem-ipsum-dolor-sit --pcap test.pcap --frame-number $frame_nr
+    test_expect_code 22 dabba capture start --interface lorem-ipsum-dolor-sit --pcap test.pcap --frame-number $frame_nr
 "
 
 test_expect_failure "Start capture thread on an invalid interface (does not exist)" "
-    test_expect_code 19 '$DABBA_PATH'/dabba capture start --interface lorem-ipsum --pcap test.pcap --frame-number $frame_nr
+    test_expect_code 19 dabba capture start --interface lorem-ipsum --pcap test.pcap --frame-number $frame_nr
 "
 
 test_expect_failure "Start capture thread with a missing interface" "
-    test_expect_code 22 '$DABBA_PATH'/dabba capture start --pcap test.pcap --frame-number $frame_nr
+    test_expect_code 22 dabba capture start --pcap test.pcap --frame-number $frame_nr
 "
 
 test_expect_failure "Start capture thread with a missing pcap path" "
-    test_expect_code 22 '$DABBA_PATH'/dabba capture start --interface any --frame-number $frame_nr
+    test_expect_code 22 dabba capture start --interface any --frame-number $frame_nr
 "
 
 test_expect_failure "Invoke capture command w/o any parameters" "
-    test_expect_code 38 '$DABBA_PATH'/dabba capture
+    test_expect_code 38 dabba capture
 "
 
 test_expect_success "Start capture thread with a default frame number" "
-    '$DABBA_PATH'/dabba capture start --interface any --pcap test.pcap &&
-    '$DABBA_PATH'/dabba capture get > result
+    dabba capture start --interface any --pcap test.pcap &&
+    dabba capture get > result
 "
 
 test_expect_success PYTHON_YAML "Parse capture YAML output" "
@@ -92,16 +92,16 @@ test_expect_success PYTHON_YAML "Check thread default capture frame number ($def
 "
 
 test_expect_success PYTHON_YAML "Stop capture thread with a default frame number" "
-    '$DABBA_PATH'/dabba capture stop --id '$(cat result_id)' &&
-    '$DABBA_PATH'/dabba capture get > after &&
+    dabba capture stop --id '$(cat result_id)' &&
+    dabba capture get > after &&
     test_must_fail grep -wq -f result_id after
 "
 
 for i in `seq 0 9`
 do
         test_expect_success "Start capture thread #$(($i+1)) on loopback" "
-            '$DABBA_PATH'/dabba capture start --interface any --pcap test$i.pcap --frame-number $frame_nr &&
-            '$DABBA_PATH'/dabba capture get > result
+            dabba capture start --interface any --pcap test$i.pcap --frame-number $frame_nr &&
+            dabba capture get > result
         "
 
         test_expect_success PYTHON_YAML "Parse capture YAML output" "
@@ -154,8 +154,8 @@ test_expect_success PYTHON_YAML "Query capture thread id to stop" "
 "
 
 test_expect_success PYTHON_YAML "Stop capture thread #0 on loopback" "
-    '$DABBA_PATH'/dabba capture stop --id '$(cat result_id)' &&
-    '$DABBA_PATH'/dabba capture get > after &&
+    dabba capture stop --id '$(cat result_id)' &&
+    dabba capture get > after &&
     test_must_fail grep -wq -f result_id after
 "
 
@@ -164,7 +164,7 @@ test_expect_success "Measure pcap file size before appending" "
 "
 
 test_expect_success "Start a capture with pcap append" "
-    '$DABBA_PATH'/dabba capture start --interface any --pcap test0.pcap --append
+    dabba capture start --interface any --pcap test0.pcap --append
 "
 
 test_expect_success "Generate some traffic to capture" "
@@ -180,8 +180,8 @@ test_expect_success "Check that appended pcap file size grows" "
 "
 
 test_expect_success "Stop all running captures thread" "
-    '$DABBA_PATH'/dabba capture stop-all &&
-    '$DABBA_PATH'/dabba capture get > result
+    dabba capture stop-all &&
+    dabba capture get > result
 "
 
 cat > expect << EOF

--- a/dabba/test/t1200-thread.sh
+++ b/dabba/test/t1200-thread.sh
@@ -55,24 +55,24 @@ check_thread_nr()
 default_cpu_affinity=$(get_default_cpu_affinity)
 
 test_expect_success "Setup: Start dabbad" "
-    '$DABBAD_PATH'/dabbad --daemonize
+    dabbad --daemonize
 "
 
 test_expect_success "Setup: Start a basic capture on loopback" "
-    '$DABBA_PATH'/dabba capture start --interface any --pcap test.pcap --frame-number 8
+    dabba capture start --interface any --pcap test.pcap --frame-number 8
 "
 
 test_expect_success "Check 'dabba thread' help output" "
-    '$DABBA_PATH/dabba' help thread | cat <<EOF
+    dabba help thread | cat <<EOF
     q
     EOF &&
-    '$DABBA_PATH/dabba' thread --help | cat <<EOF
+    dabba thread --help | cat <<EOF
     q
     EOF
 "
 
 test_expect_success "Fetch running thread information" "
-    '$DABBA_PATH'/dabba thread get settings > result
+    dabba thread get settings > result
 "
 
 test_expect_success PYTHON_YAML "Parse thread YAML output" "
@@ -125,8 +125,8 @@ do
         for priority in $min_prio $max_prio
         do
                 test_expect_success PYTHON_YAML "Modify capture thread scheduling policy ($policy:$priority)" "
-                    '$DABBA_PATH'/dabba thread modify --sched-policy '$policy' --sched-prio '$priority' --id '$thread_id' &&
-                    '$DABBA_PATH'/dabba thread get settings > result
+                    dabba thread modify --sched-policy '$policy' --sched-prio '$priority' --id '$thread_id' &&
+                    dabba thread get settings > result
                 "
 
                 test_expect_success PYTHON_YAML "Parse thread YAML output" "
@@ -153,8 +153,8 @@ do
         do
                 # Put back to 'test_must_fail' when proper error reporting is done
                 test_expect_success PYTHON_YAML "Do not modify capture thread out-of-range scheduling policy ($policy:$priority)" "
-                    test_might_fail '$DABBA_PATH'/dabba thread modify --sched-policy '$policy' --sched-prio '$priority' --id '$thread_id' &&
-                    '$DABBA_PATH'/dabba thread get settings > result
+                    test_might_fail dabba thread modify --sched-policy '$policy' --sched-prio '$priority' --id '$thread_id' &&
+                    dabba thread get settings > result
                 "
 
                 test_expect_success PYTHON_YAML "Parse thread YAML output" "
@@ -179,8 +179,8 @@ done
 for cpu_affinity in 0 $default_cpu_affinity
 do
         test_expect_success PYTHON_YAML "Modify capture thread CPU affinity (run on CPU $cpu_affinity)" "
-            '$DABBA_PATH'/dabba thread modify --cpu-affinity '$cpu_affinity' --id '$thread_id' &&
-            '$DABBA_PATH'/dabba thread get settings > result
+            dabba thread modify --cpu-affinity '$cpu_affinity' --id '$thread_id' &&
+            dabba thread get settings > result
         "
 
         test_expect_success PYTHON_YAML "Parse thread YAML output" "
@@ -198,8 +198,8 @@ do
 done
 
 test_expect_success "Stop all running captures" "
-    '$DABBA_PATH'/dabba capture stop-all &&
-    '$DABBA_PATH'/dabba thread get settings > after
+    dabba capture stop-all &&
+    dabba thread get settings > after
 "
 
 test_expect_success "Check if the capture thread is still present" "


### PR DESCRIPTION
Within the test harness, `$PATH` is no set to point to `dabba` and `dabbad`.
This means that tests are cluttered with `$DABBA_PATH` and `$DABBAD_PATH` to invoke freshly built executable.
