### PR TITLE
Add dabbad cli option to create pidfile at specific path 

### DIFF
--- a/dabba/test/dabba-test-lib.sh
+++ b/dabba/test/dabba-test-lib.sh
@@ -31,6 +31,11 @@ taskset -h > /dev/null 2>&1 && test_set_prereq TASKSET
 "$ETHTOOL_PATH" -h > /dev/null 2>&1 && test_set_prereq ETHTOOL
 test -n "$TEST_DEV" && test_set_prereq TEST_DEV
 
+mktemppid()
+{
+    mktemp dabbad.pid.XXXXXXXXXXXX
+}
+
 yaml2dict()
 {
     "$PYTHON_PATH" "$SHARNESS_TEST_DIRECTORY"/yaml2dict.py "$@"

--- a/dabba/test/t1000-interface-status.sh
+++ b/dabba/test/t1000-interface-status.sh
@@ -21,6 +21,8 @@ test_description='Test dabba interface status command'
 
 . ./dabba-test-lib.sh
 
+pidfile=$(mktemppid)
+
 generate_status(){
         rm -f dev_status
         for dev in `sed '1,2d' /proc/net/dev | awk -F ':' '{ print $1 }' | tr -d ' '`
@@ -47,7 +49,7 @@ test_expect_success 'invoke dabba interface status w/o dabbad' "
 "
 
 test_expect_success "Setup: Start dabbad" "
-    dabbad --daemonize
+    dabbad --daemonize --pidfile '$pidfile'
 "
 
 test_expect_success "Check 'dabba interface' help output" "
@@ -113,7 +115,7 @@ EOF
 done
 
 test_expect_success "Cleanup: Stop dabbad" "
-    killall dabbad
+    kill $(cat "$pidfile")
 "
 
 test_done

--- a/dabba/test/t1001-interface-driver.sh
+++ b/dabba/test/t1001-interface-driver.sh
@@ -21,6 +21,8 @@ test_description='Test dabba interface driver command'
 
 . ./dabba-test-lib.sh
 
+pidfile=$(mktemppid)
+
 test_expect_success "Setup: Stop already running dabbad" "
     test_might_fail killall dabbad
 "
@@ -30,7 +32,7 @@ test_expect_success 'invoke dabba interface driver command w/o dabbad' "
 "
 
 test_expect_success "Setup: Start dabbad" "
-    dabbad --daemonize
+    dabbad --daemonize --pidfile '$pidfile'
 "
 
 test_expect_success 'invoke dabba interface driver command with dabbad' "
@@ -57,7 +59,7 @@ do
 done
 
 test_expect_success "Cleanup: Stop dabbad" "
-    killall dabbad
+    kill $(cat "$pidfile")
 "
 
 test_done

--- a/dabba/test/t1002-interface-settings.sh
+++ b/dabba/test/t1002-interface-settings.sh
@@ -21,6 +21,7 @@ test_description='Test dabba interface settings command'
 
 . ./dabba-test-lib.sh
 
+pidfile=$(mktemppid)
 test_value=1234
 
 test_expect_success "Setup: Stop already running dabbad" "
@@ -32,7 +33,7 @@ test_expect_success 'invoke dabba interface settings command w/o dabbad' "
 "
 
 test_expect_success "Setup: Start dabbad" "
-    dabbad --daemonize
+    dabbad --daemonize --pidfile '$pidfile'
 "
 
 test_expect_success 'invoke dabba interface settings command with dabbad' "
@@ -113,7 +114,7 @@ do
 done
 
 test_expect_success "Cleanup: Stop dabbad" "
-    killall dabbad
+    kill $(cat "$pidfile")
 "
 
 test_done

--- a/dabba/test/t1003-interface-capabilities.sh
+++ b/dabba/test/t1003-interface-capabilities.sh
@@ -21,6 +21,8 @@ test_description='Test dabba interface capabilities command'
 
 . ./dabba-test-lib.sh
 
+pidfile=$(mktemppid)
+
 ethtool_port_parse() {
     local ethtool_output="$1"
     local out="{"
@@ -115,7 +117,7 @@ test_expect_success 'invoke dabba interface capabilities command w/o dabbad' "
 "
 
 test_expect_success "Setup: Start dabbad" "
-    dabbad --daemonize
+    dabbad --daemonize --pidfile '$pidfile'
 "
 
 test_expect_success 'invoke dabba interface capabilities command with dabbad' "
@@ -206,7 +208,7 @@ do
 done
 
 test_expect_success "Cleanup: Stop dabbad" "
-    killall dabbad
+    kill $(cat "$pidfile")
 "
 
 test_done

--- a/dabba/test/t1004-interface-pause.sh
+++ b/dabba/test/t1004-interface-pause.sh
@@ -21,6 +21,8 @@ test_description='Test dabba interface pause command'
 
 . ./dabba-test-lib.sh
 
+pidfile=$(mktemppid)
+
 test_expect_success "Setup: Stop already running dabbad" "
     test_might_fail killall dabbad
 "
@@ -30,7 +32,7 @@ test_expect_success 'invoke dabba interface pause command w/o dabbad' "
 "
 
 test_expect_success "Setup: Start dabbad" "
-    dabbad --daemonize
+    dabbad --daemonize --pidfile '$pidfile'
 "
 
 test_expect_success 'invoke dabba interface pause command with dabbad' "
@@ -110,7 +112,7 @@ do
 done
 
 test_expect_success "Cleanup: Stop dabbad" "
-    killall dabbad
+    kill $(cat "$pidfile")
 "
 
 test_done

--- a/dabba/test/t1005-interface-coalesce.sh
+++ b/dabba/test/t1005-interface-coalesce.sh
@@ -21,6 +21,8 @@ test_description='Test dabba interface coalesce command'
 
 . ./dabba-test-lib.sh
 
+pidfile=$(mktemppid)
+
 ethtool_coalesce_parse() {
     local pattern="$1"
     local ethtool_output="$2"
@@ -76,7 +78,7 @@ test_expect_success 'invoke dabba interface coalesce command w/o dabbad' "
 "
 
 test_expect_success "Setup: Start dabbad" "
-    dabbad --daemonize
+    dabbad --daemonize --pidfile '$pidfile'
 "
 
 test_expect_success 'invoke dabba interface coalesce command with dabbad' "
@@ -221,7 +223,7 @@ do
 done
 
 test_expect_success "Cleanup: Stop dabbad" "
-    killall dabbad
+    kill $(cat "$pidfile")
 "
 
 test_done

--- a/dabba/test/t1006-interface-offload.sh
+++ b/dabba/test/t1006-interface-offload.sh
@@ -21,6 +21,8 @@ test_description='Test dabba interface offload command'
 
 . ./dabba-test-lib.sh
 
+pidfile=$(mktemppid)
+
 ethtool_offload_long_name_get() {
     case "$1" in
         "rx-csum") echo "rx-checksumming";;
@@ -44,7 +46,7 @@ test_expect_success 'invoke dabba interface offload command w/o dabbad' "
 "
 
 test_expect_success "Setup: Start dabbad" "
-    dabbad --daemonize
+    dabbad --daemonize --pidfile '$pidfile'
 "
 
 test_expect_success 'invoke dabba interface offload command with dabbad' "
@@ -118,7 +120,7 @@ do
 done
 
 test_expect_success "Cleanup: Stop dabbad" "
-    killall dabbad
+    kill $(cat "$pidfile")
 "
 
 test_done

--- a/dabba/test/t1100-capture.sh
+++ b/dabba/test/t1100-capture.sh
@@ -21,6 +21,8 @@ test_description='Test dabba capture command'
 
 . ./dabba-test-lib.sh
 
+pidfile=$(mktemppid)
+
 get_capture_thread_nr()
 {
     local result_file=$1
@@ -40,7 +42,7 @@ frame_nr="16"
 ring_size="$(($frame_nr * 2048))" # 2kB are allocated for one ethernet frame
 
 test_expect_success "Setup: Start dabbad" "
-    dabbad --daemonize
+    dabbad --daemonize --pidfile '$pidfile'
 "
 
 test_expect_success "Check 'dabba capture' help output" "
@@ -194,7 +196,7 @@ test_expect_success "Check that the capture list is empty" "
 "
 
 test_expect_success "Cleanup: Stop dabbad" "
-    killall dabbad
+    kill $(cat "$pidfile")
 "
 
 test_done

--- a/dabba/test/t1200-thread.sh
+++ b/dabba/test/t1200-thread.sh
@@ -21,6 +21,8 @@ test_description='Test dabba thread command'
 
 . ./dabba-test-lib.sh
 
+pidfile=$(mktemppid)
+
 get_default_cpu_affinity()
 {
     taskset -pc 1 | awk '{ print $NF }'
@@ -55,7 +57,7 @@ check_thread_nr()
 default_cpu_affinity=$(get_default_cpu_affinity)
 
 test_expect_success "Setup: Start dabbad" "
-    dabbad --daemonize
+    dabbad --daemonize --pidfile '$pidfile'
 "
 
 test_expect_success "Setup: Start a basic capture on loopback" "
@@ -207,7 +209,7 @@ test_expect_success "Check if the capture thread is still present" "
 "
 
 test_expect_success "Cleanup: Stop dabbad" "
-    killall dabbad
+    kill $(cat "$pidfile")
 "
 
 test_done

--- a/dabbad/include/dabbad/misc.h
+++ b/dabbad/include/dabbad/misc.h
@@ -25,5 +25,6 @@
 #define	MISC_H
 
 int fd_to_path(const int fd, char *path, const size_t path_len);
+int create_pidfile(const char *const pidfile);
 
 #endif				/* MISC_H */

--- a/dabbad/misc.c
+++ b/dabbad/misc.c
@@ -32,11 +32,13 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
 
 #include <libdabba/strlcpy.h>
+#include <unistd.h>
 
 /**
  * \brief Path to current process open file descriptor information
@@ -129,5 +131,27 @@ int fd_to_path(const int fd, char *path, const size_t path_len)
 
  out:
 	closedir(dir);
+	return rc;
+}
+
+int create_pidfile(const char *const pidfile)
+{
+	int pidfd, len, rc = 0;
+	char pidstr[8];
+
+	assert(pidfile);
+
+	pidfd = open(pidfile, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR);
+
+	if (pidfd < 0)
+		return errno;
+
+	len = snprintf(pidstr, sizeof(pidstr), "%u", getpid());
+
+	if (write(pidfd, pidstr, len) != len)
+		rc = errno;
+
+	close(pidfd);
+
 	return rc;
 }


### PR DESCRIPTION
There should an option to tell the daemon to create a PID file at a specific path.
It would allow the tests to keep track of the started daemon PID to kill only this `dabbad` process during the cleanup operations.
