### PR TITLE
Travis python yaml support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ branches:
   only:
     - master
 
-# Notify the LuaDist Dev group if needed
 notifications:
   recipients:
     - emmanuel.roullit@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
   - clang
 
 # Make sure CMake is installed on target
-install: sudo apt-get install cmake libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libcap2-bin protobuf-c-compiler libprotobuf-c0-dev
+install: sudo apt-get install cmake libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libcap2-bin protobuf-c-compiler libprotobuf-c0-dev python-yaml
 
 # Build a release version and get verbose output
 env:


### PR DESCRIPTION
Travis skips a lot of test as it does not have the python-yaml package installed.
It leads to a lot of tests being skipped and it reduces the test coverage.
These commits tries to install the python-yaml package on the test enviromnent, let's see if Travis knows about it.
