### PR TITLE
Thread type stays unset on thread creation

### DIFF
--- a/dabba/cli.c
+++ b/dabba/cli.c
@@ -195,7 +195,8 @@ const char *sched_policy2str(const int policy)
 const char *thread_type2str(const int type)
 {
 	static const char thread_type[][8] = {
-		[CAPTURE_THREAD] = "capture"
+		[CAPTURE_THREAD] = "capture",
+		[REPLAY_THREAD] = "replay"
 	};
 
 	const int max = ARRAY_SIZE(thread_type);

--- a/dabbad/capture.c
+++ b/dabbad/capture.c
@@ -272,6 +272,8 @@ void dabbad_capture_start(Dabba__DabbaService_Service * service,
 		goto out;
 	}
 
+	pkt_capture->thread.type = CAPTURE_THREAD;
+
 	if (capturep->append)
 		pkt_capture->rx.pcap_fd =
 		    pcap_open(capturep->pcap, O_RDWR | O_APPEND);

--- a/dabbad/include/dabbad/thread.h
+++ b/dabbad/include/dabbad/thread.h
@@ -41,7 +41,8 @@
  */
 
 enum packet_thread_type {
-	CAPTURE_THREAD
+	CAPTURE_THREAD,
+	REPLAY_THREAD
 };
 
 /**

--- a/dabbad/replay.c
+++ b/dabbad/replay.c
@@ -272,6 +272,7 @@ void dabbad_replay_start(Dabba__DabbaService_Service * service,
 		goto out;
 	}
 
+	pkt_replay->thread.type = REPLAY_THREAD;
 	pkt_replay->tx.pcap_fd = pcap_open(replayp->pcap, O_RDONLY);
 
 	if (pkt_replay->tx.pcap_fd < 0) {


### PR DESCRIPTION
When a replay or a capture thread is created, the thread type is not set. Therefore, when the thread list is fetched via `dabba thread get`, all threads are shown as capture threads.
