### PR TITLE
Core dump generation

### DIFF
--- a/dabbad/dabbad.c
+++ b/dabbad/dabbad.c
@@ -217,14 +217,14 @@ int main(int argc, char **argv)
 		}
 	}
 
-	core_enable();
-
 	if (daemonize) {
 		if (daemon(-1, 0)) {
 			perror("Could not daemonize process");
 			return errno;
 		}
 	}
+
+	core_enable();
 
 	if (pidfile)
 		rc = create_pidfile(pidfile);

--- a/dabbad/dabbad.c
+++ b/dabbad/dabbad.c
@@ -217,6 +217,8 @@ int main(int argc, char **argv)
 		}
 	}
 
+	core_enable();
+
 	if (daemonize) {
 		if (daemon(-1, 0)) {
 			perror("Could not daemonize process");

--- a/dabbad/include/dabbad/misc.h
+++ b/dabbad/include/dabbad/misc.h
@@ -26,5 +26,6 @@
 
 int fd_to_path(const int fd, char *path, const size_t path_len);
 int create_pidfile(const char *const pidfile);
+int core_enable(void);
 
 #endif				/* MISC_H */

--- a/dabbad/misc.c
+++ b/dabbad/misc.c
@@ -35,6 +35,8 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/resource.h>
+#include <sys/prctl.h>
 #include <dirent.h>
 
 #include <libdabba/strlcpy.h>
@@ -162,4 +164,24 @@ int create_pidfile(const char *const pidfile)
 	close(pidfd);
 
 	return rc;
+}
+
+static int core_rlimit_get(struct rlimit *const lim)
+{
+	assert(lim);
+	return getrlimit(RLIMIT_CORE, lim) ? errno : 0;
+}
+
+static int core_rlimit_set(const struct rlimit *const lim)
+{
+	assert(lim);
+	return setrlimit(RLIMIT_CORE, lim) ? errno : 0;
+}
+
+int core_enable(void)
+{
+	struct rlimit lim;
+	core_rlimit_get(&lim);
+	lim.rlim_cur = lim.rlim_max;
+	return (core_rlimit_set(&lim) || prctl(PR_SET_DUMPABLE, 1)) ? errno : 0;
 }

--- a/dabbad/misc.c
+++ b/dabbad/misc.c
@@ -166,17 +166,36 @@ int create_pidfile(const char *const pidfile)
 	return rc;
 }
 
+/**
+ * \brief Fetch current core file size limit settings
+ * \param[out]	lim 	Pointer to file size limit structure
+ * \return 0 on success, \c errno on failure.
+ */
+
 static int core_rlimit_get(struct rlimit *const lim)
 {
 	assert(lim);
 	return getrlimit(RLIMIT_CORE, lim) ? errno : 0;
 }
 
+/**
+ * \brief Set core file size limit settings
+ * \param[in]	lim 	Pointer to file size limit structure
+ * \return 0 on success, \c errno on failure.
+ */
+
 static int core_rlimit_set(const struct rlimit *const lim)
 {
 	assert(lim);
 	return setrlimit(RLIMIT_CORE, lim) ? errno : 0;
 }
+
+/**
+ * \brief Enable dabba to generate a core dump file
+ * \return 0 on success, \c errno on failure.
+ * \note it raises the core file size limit to the maximum allowed
+ * \note it sets process flags to produce core dumps
+ */
 
 int core_enable(void)
 {


### PR DESCRIPTION
To ease debugging, the daemon should try to create a core dump when it terminates unexpectedly.
If the system reports an error while enabling it, just carry on initialization normally.
